### PR TITLE
[dynamo/expressions/updates] Fixed incorrect falsy for index 0

### DIFF
--- a/lib/dynamo/expressions/create.test.ts
+++ b/lib/dynamo/expressions/create.test.ts
@@ -287,6 +287,33 @@ describe('Dynamo Expression Builder', () => {
       expect(result).toEqual(expectedResult)
     })
 
+    it('should create an update expression to edit the first item in a list if index is 0', () => {
+      const conditions = {
+        tableName: 'Users',
+        where: {
+          id: { primary: true, value: userId },
+        },
+        update: {
+          spaces: { value: { id: spaceId, role: userRole, index: 0 } },
+        },
+        operation: DBOperations.Update,
+      }
+
+      const result = createExpression(conditions)
+
+      const expectedResult = {
+        TableName: 'Users',
+        Key: { id: userId },
+        ExpressionAttributeNames: { '#spaces': 'spaces' },
+        ExpressionAttributeValues: {
+          ':spaces': { id: spaceId, role: userRole },
+        },
+        UpdateExpression: 'SET #spaces[0] = :spaces',
+      }
+
+      expect(result).toEqual(expectedResult)
+    })
+
     it('should create an update expression to append list items', () => {
       const conditions = {
         tableName: 'Users',

--- a/lib/dynamo/expressions/updates.ts
+++ b/lib/dynamo/expressions/updates.ts
@@ -121,7 +121,7 @@ export function processUpdateExpression(
 
       if (
         keyValues.value &&
-        keyValues.value.index &&
+        typeof keyValues.value.index !== 'undefined' &&
         keyValues.value.index >= 0
       ) {
         return `#${key}[${keyValues.value.index}] = :${key}`


### PR DESCRIPTION
### WHY are these changes introduced?

Admin GraphQL had a bug where updating a user's role for a space would change `spaces` on the user from `List` to `Map`.

### WHAT is this pull request doing?

Fixes an if statement to check for `typeof keyValues.value.index !== 'undefined'` because `keyValues.value.index` would be false if the `index` was `0`.

Changing this if statement changes the update expression in this case from `SET #spaces = :spaces` to `SET #spaces[0] = :spaces`.