### PR TITLE
Merging dev to master. Making spaceId optional

### DIFF
--- a/lib/is-feature-allowed/index.ts
+++ b/lib/is-feature-allowed/index.ts
@@ -19,11 +19,15 @@ export const isFeatureAllowed = async ({
 }): Promise<boolean> => {
   if (envOverride) return true
 
+  if (!space && !spaceId) return false
+
   const featureFlags = space ? space?.featureFlags : await getFeatureFlags(spaceId)
   return featureFlags?.indexOf(featureName) > -1
 }
 
 const getFeatureFlags = async (spaceId: string): Promise<string[]> => {
+  if (!spaceId) return []
+
   const queryConditions = {
     tableName: 'Spaces',
     where: {

--- a/lib/is-feature-allowed/index.ts
+++ b/lib/is-feature-allowed/index.ts
@@ -8,18 +8,18 @@ const dynamoDb = dynamoTools.init(
 
 export const isFeatureAllowed = async ({
   featureName,
-  spaceId,
+  spaceId = null,
   space = null,
   envOverride = false
 }: {
   featureName: string,
-  spaceId: string,
+  spaceId?: string,
   space?: Space,
   envOverride?: boolean
 }): Promise<boolean> => {
   if (envOverride) return true
 
-  const featureFlags = space ? space.featureFlags : await getFeatureFlags(spaceId)
+  const featureFlags = space ? space?.featureFlags : await getFeatureFlags(spaceId)
   return featureFlags?.indexOf(featureName) > -1
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Makes the spaceId param to isFeatureAllowed function optional.

### WHAT is this pull request doing?

We decided it's best to not use the dynamoDB operations in lambda-tools when not on a lambda (potential permissions errors). Therefore we only want to pass the space instead of the spaceId. In this case it's redundant to pass both.

### How to Test
Use this function passing only the `space` param (without an accompanying `spaceId` param).