### PR TITLE
Added logHttpEvent

### DIFF
--- a/lib/logger/logger.test.ts
+++ b/lib/logger/logger.test.ts
@@ -1,6 +1,7 @@
+import { APIGatewayEvent } from 'aws-lambda'
 import { DocumentNode } from 'graphql'
 
-import { logResolverLifecycle, logger } from './logger'
+import { logResolver, logHttpEvent, logger } from './logger'
 
 interface ResolverArgs {
   chicken: string
@@ -22,7 +23,15 @@ const errorResolver = () => {
   throw new Error('I dropped the eggs!')
 }
 
-describe('lifeCycleLogger()', () => {
+const handler = (event: APIGatewayEvent) => {
+  return Promise.resolve(`bacon & ${event.body}`)
+}
+
+const errorHandler = () => {
+  throw new Error('I dropped the eggs!')
+}
+
+describe('logResolver()', () => {
   beforeEach(() => {
     Object.defineProperties(logger, {
       info: { value: jest.fn() },
@@ -31,7 +40,7 @@ describe('lifeCycleLogger()', () => {
   })
 
   it('should log the lifecycle events in a resolver', async () => {
-    const wrappedResolver = logResolverLifecycle('make breakfast', resolver)
+    const wrappedResolver = logResolver('make breakfast', resolver)
     const result = await wrappedResolver(
       undefined,
       { chicken: 'eggs' },
@@ -44,17 +53,15 @@ describe('lifeCycleLogger()', () => {
       args: { chicken: 'eggs' },
       context: { userEmail: 'yummy@me.com' },
       action: 'make breakfast',
-      lifeCycle: 'Start',
     })
-    expect(logger.info).toHaveBeenCalledWith('Sending Result', {
+    expect(logger.info).toHaveBeenCalledWith('Sending Response', {
       action: 'make breakfast',
-      lifeCycle: 'End',
     })
     expect(logger.info).toHaveBeenCalledTimes(2)
   })
 
   it('should log a custom error message', async () => {
-    const wrappedResolver = logResolverLifecycle(
+    const wrappedResolver = logResolver(
       'make breakfast',
       errorResolver,
       'You did a bad'
@@ -74,7 +81,6 @@ describe('lifeCycleLogger()', () => {
         args: { chicken: 'eggs' },
         context: { userEmail: 'yummy@me.com' },
         action: 'make breakfast',
-        lifeCycle: 'Start',
       })
       expect(logger.error).toHaveBeenCalledTimes(1)
       expect(logger.error).toHaveBeenCalledWith(expect.any(String), {
@@ -92,10 +98,7 @@ describe('lifeCycleLogger()', () => {
   })
 
   it('should catch and log generic errors', async () => {
-    const wrappedResolver = logResolverLifecycle(
-      'make breakfast',
-      errorResolver
-    )
+    const wrappedResolver = logResolver('make breakfast', errorResolver)
 
     try {
       const result = await wrappedResolver(
@@ -111,13 +114,89 @@ describe('lifeCycleLogger()', () => {
         args: { chicken: 'eggs' },
         context: { userEmail: 'yummy@me.com' },
         action: 'make breakfast',
-        lifeCycle: 'Start',
       })
       expect(logger.error).toHaveBeenCalledTimes(1)
       expect(logger.error).toHaveBeenCalledWith(expect.any(String), {
         parent: undefined,
         args: { chicken: 'eggs' },
         context: { userEmail: 'yummy@me.com' },
+        action: 'make breakfast',
+        error: expect.anything(),
+      })
+      expect(err.message).toContain('Failed to make breakfast')
+      expect(err.message).toContain('Error Id:')
+      expect(err.message).toContain('I dropped the eggs!')
+    }
+  })
+})
+
+describe('logHttpEvent()', () => {
+  beforeEach(() => {
+    Object.defineProperties(logger, {
+      info: { value: jest.fn() },
+      error: { value: jest.fn() },
+    })
+  })
+
+  it('should log the lifecycle events in a resolver', async () => {
+    const wrappedHttpEvent = logHttpEvent('make breakfast', handler)
+    const result = await wrappedHttpEvent({ body: 'eggs' } as APIGatewayEvent)
+
+    expect(result).toEqual(`bacon & eggs`)
+    expect(logger.info).toHaveBeenCalledWith('Request Received', {
+      event: { body: 'eggs' },
+      action: 'make breakfast',
+    })
+    expect(logger.info).toHaveBeenCalledWith('Sending Response', {
+      action: 'make breakfast',
+    })
+    expect(logger.info).toHaveBeenCalledTimes(2)
+  })
+
+  it('should log a custom error message', async () => {
+    const wrappedHttpEvent = logHttpEvent(
+      'make breakfast',
+      errorHandler,
+      'You did a bad'
+    )
+
+    try {
+      const result = await wrappedHttpEvent({ body: 'eggs' } as APIGatewayEvent)
+      expect(result).toBeUndefined()
+    } catch (err) {
+      expect(logger.info).toHaveBeenCalledTimes(1)
+      expect(logger.info).toHaveBeenCalledWith('Request Received', {
+        event: { body: 'eggs' },
+        action: 'make breakfast',
+      })
+      expect(logger.error).toHaveBeenCalledTimes(1)
+      expect(logger.error).toHaveBeenCalledWith(expect.any(String), {
+        event: { body: 'eggs' },
+        action: 'make breakfast',
+        error: expect.anything(),
+      })
+      expect(err.message).toContain(
+        'Error: Failed to make breakfast. You did a bad. Error Id: '
+      )
+      expect(err.message).toContain('I dropped the eggs!')
+    }
+  })
+
+  it('should catch and log generic errors', async () => {
+    const wrappedHttpEvent = logHttpEvent('make breakfast', errorHandler)
+
+    try {
+      const result = await wrappedHttpEvent({ body: 'eggs' } as APIGatewayEvent)
+      expect(result).toBeUndefined()
+    } catch (err) {
+      expect(logger.info).toHaveBeenCalledTimes(1)
+      expect(logger.info).toHaveBeenCalledWith('Request Received', {
+        event: { body: 'eggs' },
+        action: 'make breakfast',
+      })
+      expect(logger.error).toHaveBeenCalledTimes(1)
+      expect(logger.error).toHaveBeenCalledWith(expect.any(String), {
+        event: { body: 'eggs' },
         action: 'make breakfast',
         error: expect.anything(),
       })

--- a/lib/logger/logger.ts
+++ b/lib/logger/logger.ts
@@ -1,19 +1,14 @@
 import { DocumentNode } from 'graphql'
 import { v4 } from 'uuid'
 import { LambdaLog } from 'lambda-log'
+import { APIGatewayEvent } from 'aws-lambda'
 
-const logger: LambdaLog = new LambdaLog({
+export const logger: LambdaLog = new LambdaLog({
   dev: process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test',
   debug: true,
 })
 
-export enum RequestLifeCycle {
-  Start = 'Start',
-  Processing = 'Processing',
-  End = 'End',
-}
-
-export function logResolverLifecycle<T, U, V>(
+export function logResolver<T, U, V>(
   action = 'Perform Operation',
   resolver: (parent: DocumentNode, args: T, context: U) => Promise<V>,
   customErrorMessage?: string
@@ -29,24 +24,51 @@ export function logResolverLifecycle<T, U, V>(
         args,
         context,
         action,
-        lifeCycle: RequestLifeCycle.Start,
       })
 
-      const result = await resolver(parent, args, context)
-      logger.info('Sending Result', { action, lifeCycle: RequestLifeCycle.End })
+      const response = await resolver(parent, args, context)
+      logger.info('Sending Response', { action })
 
-      return result
-    } catch (err) {
-      const errorId = v4()
-      const message = customErrorMessage
-        ? `Error: Failed to ${action}. ${customErrorMessage}. Error Id: ${errorId}. ${err.message}`
-        : `Error: Failed to ${action}. Error Id: ${errorId}. ${err.message}`
-
-      logger.error(message, { parent, args, context, action, error: err.stack })
+      return response
+    } catch (error) {
+      const message = logError(
+        error,
+        action,
+        { parent, args, context },
+        customErrorMessage
+      )
 
       throw new Error(message)
     }
   }
 }
 
-export { logger }
+export const logHttpEvent = <T>(
+  action = 'Perform Operation',
+  handler: (event: APIGatewayEvent) => Promise<T>,
+  customErrorMessage?: string
+) => async (event: APIGatewayEvent): Promise<T> => {
+  try {
+    logger.info(`Request Received`, { event, action })
+    const response = await handler(event)
+    logger.info(`Sending Response`, { action })
+    return response
+  } catch (error) {
+    throw new Error(logError(error, action, { event }, customErrorMessage))
+  }
+}
+
+export const logError = (
+  error: Error,
+  action: string,
+  meta?: Record<string, unknown> | undefined,
+  customErrorMessage?: string
+): string => {
+  const errorId = v4()
+  const customErrorSentence = customErrorMessage
+    ? ` ${customErrorMessage}.`
+    : ''
+  const message = `Error: Failed to ${action}.${customErrorSentence} Error Id: ${errorId}. ${error.message}`
+  logger.error(message, { action, ...meta, error: error.stack })
+  return message
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/lambda-tools",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Re-usable utility functions useful when working with Serverless lambdas",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
### WHY are these changes introduced?

We need a logging function for `APIGatewayEvent` (non-graphql) lambdas

### WHAT is this pull request doing?

Adds `logHttpEvent` for logging an `APIGatewayEvent`. This is very similar to `logResolver` which is for logging GraphQL resolvers. 

Renames `logResolverLifeCycle` to `logResolver`. I removed `lifeCycle` property from events because it seemed redundant, doesn't seem to be used, and just added complexity. Thus having "LifeCycle" in the function name doesn't make sense.