### PR TITLE
bumped major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/lambda-tools",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Re-usable utility functions useful when working with Serverless lambdas",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Bump major version to 3.0.0 because latest code has a breaking change (function name change)