### PR TITLE
ENG-2079 add s3 directory delete function

### DIFF
--- a/lib/s3/index.ts
+++ b/lib/s3/index.ts
@@ -1,3 +1,3 @@
-import { s3Tools } from './storage'
+import { s3Tools, S3Tools } from './storage'
 
-export { s3Tools }
+export { s3Tools, S3Tools }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/lambda-tools",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/lambda-tools",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Re-usable utility functions useful when working with Serverless lambdas",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
### WHY are these changes introduced?

For [[ENG-2079](https://nacelle.atlassian.net/browse/ENG-2079)]

We want to easily add and remove spaces from all of the product recommendation/merchandising functionality. The `s3Tools.emptyDirectory()` function will be used by pulse inverter to empty and delete the s3 directory for a space in the `nacellemerchandising[-dev]` bucket.

### WHAT is this pull request doing?

Adds `s3Tools.emptyDirectory()` function.